### PR TITLE
Added maintener, source_url, Berksfile, and .gitignore to standardize…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,16 @@
+.vagrant
+Berksfile.lock
+*~
+*#
+.#*
+\#*#
+.*.sw[a-z]
+*.un~
+
+# Bundler
+Gemfile.lock
+bin/*
+.bundle/*
+
+.kitchen/
+.kitchen.local.yml

--- a/Berksfile
+++ b/Berksfile
@@ -1,0 +1,3 @@
+source 'https://supermarket.chef.io'
+
+metadata

--- a/metadata.rb
+++ b/metadata.rb
@@ -1,7 +1,9 @@
 name             "sc"
+maintainer       "Justin Schuhmann"
 maintainer_email "Justin.Schuhmann@gmail.com"
 description      "Manages Windows Services with SC"
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          "2.0.0"
+source_url 'https://github.com/EasyAsABC123/sc'
+version          "2.0.1"
 supports         "windows"
 depends          "windows", ">= 1.2.6"


### PR DESCRIPTION
… and allow this to work with later versions of berks

Please pull these changes.  SC won't work with Berks unless you have a maintainter entry in the metadata.rb.  I also added the source_url, a .gitignore, Berksfile (with the community supermarket.chef.io), and bumped the version.  Thanks!
